### PR TITLE
Fix randomInt() method when limit < 2

### DIFF
--- a/Sources/NinetyNineSwiftProblems/Random.swift
+++ b/Sources/NinetyNineSwiftProblems/Random.swift
@@ -1,6 +1,9 @@
 import Foundation
 
 public func randomInt(under limit: Int) -> Int {
+    if limit < 2 {
+        return 0
+    }
     #if os(Linux)
         srandom(UInt32(time(nil)))
         return random() % limit


### PR DESCRIPTION
When limit is less than 2, `randomInt()` should always return 0.